### PR TITLE
Add deck wrapper to enable stdout capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,28 @@ jobs:
           deck-version: 1.7.0
       - run: deck version
 ```
+
+## Capturing output
+
+If you need to capture the output for use in a later step, you can add a wrapper script which exposes `stdout`, `stderr` and `exitcode` by passing the `wrapper` input and setting it to `true`:
+
+```yaml
+steps:
+  - uses: kong/setup-deck@v1
+    with:
+      deck-version: 1.7.0
+      wrapper: true
+  - run: deck version
+    id: deck_version
+  - run: echo '${{ toJson(steps.deck_version.outputs) }}'
+```
+
+This would produce the following output:
+
+```json
+{
+  "exitcode": "0",
+  "stderr": "",
+  "stdout": "decK v1.7.0 (de1c830) \n"
+}
+```

--- a/__mocks__/actions-output-wrapper.js
+++ b/__mocks__/actions-output-wrapper.js
@@ -1,0 +1,1 @@
+module.exports = jest.fn();

--- a/action.yml
+++ b/action.yml
@@ -7,3 +7,7 @@ inputs:
   deck-version:
     description: The version of decK to install
     required: true
+  wrapper:
+    description: Add a wrapper script to make stdout, stderr and errorcode available as outputs
+    default: "false"
+    required: false

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const tc = require("@actions/tool-cache");
 const core = require("@actions/core");
 const semver = require("semver");
+const createWrapper = require("actions-output-wrapper");
 
 async function action() {
   const version = core.getInput("deck-version", { required: true });
@@ -26,7 +27,11 @@ async function action() {
 
     deckDirectory = await tc.cacheDir(deckExtractedFolder, "deck", fullVersion);
   }
+
   core.addPath(deckDirectory);
+  if (core.getInput("wrapper") === "true") {
+    await createWrapper("deck");
+  }
 }
 
 function getPlatform(platform) {

--- a/index.test.js
+++ b/index.test.js
@@ -1,10 +1,13 @@
 const action = require("./index");
 const tc = require("@actions/tool-cache");
 const core = require("@actions/core");
+jest.mock("actions-output-wrapper");
+let createWrapper = require("actions-output-wrapper");
 
 let originalPlatform;
 beforeEach(() => {
   jest.spyOn(console, "log").mockImplementation();
+  createWrapper.mockClear();
   originalPlatform = process.platform;
 });
 
@@ -106,6 +109,34 @@ describe("install", () => {
     expect(tc.downloadTool).toBeCalledWith(
       `https://github.com/Kong/deck/releases/download/v1.7.0/deck_1.7.0_${os}_amd64.tar.gz`
     );
+  });
+});
+
+describe("wrapper", () => {
+  it("does not apply the wrapper by default", async () => {
+    process.env["INPUT_DECK-VERSION"] = "1.7.0";
+    process.env["INPUT_WRAPPER"] = "false";
+
+    setPlatform("linux");
+    mockToolIsInCache(true);
+    mockExtraction();
+
+    await action();
+
+    expect(createWrapper).toBeCalledTimes(0);
+  });
+
+  it("applies the wrapper when enabled", async () => {
+    process.env["INPUT_DECK-VERSION"] = "1.7.0";
+    process.env["INPUT_WRAPPER"] = "true";
+
+    setPlatform("linux");
+    mockToolIsInCache(true);
+    mockExtraction();
+
+    await action();
+
+    expect(createWrapper).toBeCalledTimes(1);
   });
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,11 @@
   "packages": {
     "": {
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.3.0",
         "@actions/tool-cache": "^1.6.1",
+        "actions-output-wrapper": "^1.0.0",
         "semver": "^6.3.0"
       },
       "devDependencies": {
@@ -17,14 +18,14 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.3.0.tgz",
-      "integrity": "sha512-xxtX0Cwdhb8LcgatfJkokqT8KzPvcIbwL9xpLU09nOwBzaStbfm0dNncsP0M4us+EpoPdWy7vbzU5vSOH7K6pg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-CGx2ilGq5i7zSLgiiGUtBCxhRRxibJYU6Fim0Q1Wg2aQL2LTnF27zbqZOrxfvFQ55eSBW0L8uVStgtKMpa0Qlg=="
     },
     "node_modules/@actions/exec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.0.4.tgz",
-      "integrity": "sha512-4DPChWow9yc9W3WqEbUj8Nr86xkpyE29ZzWjXucHItclLbEW6jr80Zx4nqv18QL6KK65+cifiQZXvnqgTV6oHw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.0.tgz",
+      "integrity": "sha512-LImpN9AY0J1R1mEYJjVJfSZWU4zYOlEcwSTgPve1rFQqK5AwrEs6uWW5Rv70gbDIQIAUwI86z6B+9mPK4w9Sbg==",
       "dependencies": {
         "@actions/io": "^1.0.1"
       }
@@ -38,9 +39,9 @@
       }
     },
     "node_modules/@actions/io": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.0.tgz",
-      "integrity": "sha512-PspSX7Z9zh2Fyyuf3F6BsYeXcYHfc/VJ1vwy2vouas95efHVd42M6UfBFRs+jY0uiMDXhAoUtATn9g2r1MaWBQ=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.1.tgz",
+      "integrity": "sha512-Qi4JoKXjmE0O67wAOH6y0n26QXhMKMFo7GD/4IXNVcrtLjUlGjGuVys6pQgwF3ArfGTQu0XpqaNr0YhED2RaRA=="
     },
     "node_modules/@actions/tool-cache": {
       "version": "1.6.1",
@@ -1006,6 +1007,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/actions-output-wrapper": {
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/mheap/actions-output-wrapper.git#db0f611245885b68b5a484469ab345808335abfb",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/core": "^1.4.0",
+        "@actions/exec": "^1.1.0",
+        "@actions/io": "^1.1.1"
       }
     },
     "node_modules/agent-base": {
@@ -3933,14 +3944,14 @@
   },
   "dependencies": {
     "@actions/core": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.3.0.tgz",
-      "integrity": "sha512-xxtX0Cwdhb8LcgatfJkokqT8KzPvcIbwL9xpLU09nOwBzaStbfm0dNncsP0M4us+EpoPdWy7vbzU5vSOH7K6pg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-CGx2ilGq5i7zSLgiiGUtBCxhRRxibJYU6Fim0Q1Wg2aQL2LTnF27zbqZOrxfvFQ55eSBW0L8uVStgtKMpa0Qlg=="
     },
     "@actions/exec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.0.4.tgz",
-      "integrity": "sha512-4DPChWow9yc9W3WqEbUj8Nr86xkpyE29ZzWjXucHItclLbEW6jr80Zx4nqv18QL6KK65+cifiQZXvnqgTV6oHw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.0.tgz",
+      "integrity": "sha512-LImpN9AY0J1R1mEYJjVJfSZWU4zYOlEcwSTgPve1rFQqK5AwrEs6uWW5Rv70gbDIQIAUwI86z6B+9mPK4w9Sbg==",
       "requires": {
         "@actions/io": "^1.0.1"
       }
@@ -3954,9 +3965,9 @@
       }
     },
     "@actions/io": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.0.tgz",
-      "integrity": "sha512-PspSX7Z9zh2Fyyuf3F6BsYeXcYHfc/VJ1vwy2vouas95efHVd42M6UfBFRs+jY0uiMDXhAoUtATn9g2r1MaWBQ=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.1.tgz",
+      "integrity": "sha512-Qi4JoKXjmE0O67wAOH6y0n26QXhMKMFo7GD/4IXNVcrtLjUlGjGuVys6pQgwF3ArfGTQu0XpqaNr0YhED2RaRA=="
     },
     "@actions/tool-cache": {
       "version": "1.6.1",
@@ -4782,6 +4793,15 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
       "dev": true
+    },
+    "actions-output-wrapper": {
+      "version": "git+ssh://git@github.com/mheap/actions-output-wrapper.git#db0f611245885b68b5a484469ab345808335abfb",
+      "from": "actions-output-wrapper@^1.0.0",
+      "requires": {
+        "@actions/core": "^1.4.0",
+        "@actions/exec": "^1.1.0",
+        "@actions/io": "^1.1.1"
+      }
     },
     "agent-base": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@actions/core": "^1.3.0",
     "@actions/tool-cache": "^1.6.1",
+    "actions-output-wrapper": "^1.0.0",
     "semver": "^6.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR enables the capture of `stdout`, `stderr` and `exitcode` as suggested in #2.

It delegates to https://github.com/mheap/actions-output-wrapper to create the shim wrapper