### PR TITLE
tasks(deps) exclude prerelease

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ async function action() {
         continue;
       }
       
-      version = releases[0].tag_name.replace(/^v/, "");
+      version = releases[i].tag_name.replace(/^v/, "");
       break;
     }
     

--- a/index.js
+++ b/index.js
@@ -19,8 +19,19 @@ async function action() {
     if (!releases.length) {
       throw new Error(`No releases found in kong/deck`);
     }
-
-    version = releases[0].tag_name.replace(/^v/, "");
+    
+    for(let i=0; i < releases.length; i++) {
+      if(releases[i].prerelease) {
+        continue;
+      }
+      
+      version = releases[0].tag_name.replace(/^v/, "");
+      break;
+    }
+    
+    if (!version) {
+      throw new Error(`No releases (excluding prereleases) found in kong/deck`);
+    }
   }
 
   const semverVersion = semver.valid(semver.coerce(version));


### PR DESCRIPTION
decK created a prelease that doesn't have artifacts, causing the actions failed to fetch artifacts.

This commits skips prereleases so that we can fallback to ones that actually has artifact.