### PR TITLE
Feat(*): Add `arm64` Support

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,12 +41,14 @@ async function action() {
   }
 
   let os = getPlatform(process.platform);
+  let arch = getArch(process.arch);
+
   const fullVersion = `${semverVersion}-${os}`;
-  console.log(`Installing decK version ${fullVersion}`);
+  console.log(`Installing decK version ${fullVersion} for ${arch}`);
 
   let deckDirectory = tc.find("deck", fullVersion);
   if (!deckDirectory) {
-    const versionUrl = `https://github.com/Kong/deck/releases/download/v${semverVersion}/deck_${semverVersion}_${os}_amd64.tar.gz`;
+    const versionUrl = `https://github.com/Kong/deck/releases/download/v${semverVersion}/deck_${semverVersion}_${os}_${arch}.tar.gz`;
     const deckPath = await tc.downloadTool(versionUrl);
 
     const deckExtractedFolder = await tc.extractTar(
@@ -75,6 +77,14 @@ function getPlatform(platform) {
   }
 
   return "linux";
+}
+
+function getArch(arch) {
+  if (process.arch === "x64") {
+    return "amd64";
+  }
+
+  return process.arch;
 }
 
 if (require.main === module) {

--- a/index.js
+++ b/index.js
@@ -19,16 +19,16 @@ async function action() {
     if (!releases.length) {
       throw new Error(`No releases found in kong/deck`);
     }
-    
+
     for(let i=0; i < releases.length; i++) {
       if(releases[i].prerelease) {
         continue;
       }
-      
+
       version = releases[i].tag_name.replace(/^v/, "");
       break;
     }
-    
+
     if (!version) {
       throw new Error(`No releases (excluding prereleases) found in kong/deck`);
     }

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ async function action() {
   let arch = getArch(process.arch);
 
   const fullVersion = `${semverVersion}-${os}`;
-  console.log(`Installing decK version ${fullVersion} for ${arch}`);
+  console.log(`Installing decK version ${fullVersion}`);
 
   let deckDirectory = tc.find("deck", fullVersion);
   if (!deckDirectory) {

--- a/index.test.js
+++ b/index.test.js
@@ -10,6 +10,7 @@ jest.mock("actions-output-wrapper");
 let createWrapper = require("actions-output-wrapper");
 
 let originalPlatform;
+let originalArch;
 let restore;
 let restoreTest;
 
@@ -22,6 +23,7 @@ beforeEach(() => {
   jest.spyOn(console, "log").mockImplementation();
   createWrapper.mockClear();
   originalPlatform = process.platform;
+  originalArch = process.arch;
 });
 
 afterEach(() => {
@@ -37,6 +39,7 @@ afterEach(() => {
   }
   nock.cleanAll();
   setPlatform(originalPlatform);
+  setArch(originalArch);
 });
 
 describe("automatic version fetching", () => {
@@ -143,6 +146,7 @@ describe("install", () => {
     });
 
     setPlatform("linux");
+    setArch("amd64");
     mockToolIsInCache(false);
     mockTcDownload();
     mockExtraction();
@@ -172,6 +176,7 @@ describe("install", () => {
     });
 
     setPlatform(platform);
+    setArch("amd64");
     mockToolIsInCache(false);
     mockTcDownload();
     mockExtraction();

--- a/index.test.js
+++ b/index.test.js
@@ -182,6 +182,29 @@ describe("install", () => {
       `https://github.com/Kong/deck/releases/download/v1.7.0/deck_1.7.0_${os}_amd64.tar.gz`
     );
   });
+
+  const archCases = [
+    ["x64", "amd64"],
+    ["arm64", "arm64"],
+  ];
+
+  test.each(archCases)("downloads correctly for %s", async (node_arch, arch) => {
+    restoreTest = mockEnv({
+      "INPUT_DECK-VERSION": "1.7.0",
+    });
+
+    setPlatform("linux");
+    setArch(node_arch);
+    mockToolIsInCache(false);
+    mockTcDownload();
+    mockExtraction();
+
+    await action();
+
+    expect(tc.downloadTool).toBeCalledWith(
+      `https://github.com/Kong/deck/releases/download/v1.7.0/deck_1.7.0_linux_${arch}.tar.gz`
+    );
+  });
 });
 
 describe("wrapper", () => {
@@ -224,6 +247,12 @@ function mockToolIsInCache(exists) {
 function setPlatform(platform) {
   Object.defineProperty(process, "platform", {
     value: platform,
+  });
+}
+
+function setArch(arch) {
+  Object.defineProperty(process, "arch", {
+    value: arch,
   });
 }
 


### PR DESCRIPTION
This PR adds support for collecting the OS's architecture from `process.arch` to allow the action to fetch `arm64` binaries when called for. Also lumped in some tests.

I'm very much not a NodeJS person, so feedback would be greatly appreciated.